### PR TITLE
Spell out argument tamper vs recover

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -1,3 +1,8 @@
+---
+output: 
+  html_document: 
+    keep_md: yes
+---
 
 ```{r, setup, echo = FALSE, message = FALSE}
 knitr::opts_chunk$set(
@@ -13,7 +18,7 @@ knitr::opts_chunk$set(
 > Easier Debugging of `magrittr` Pipes
 
 [![Linux Build Status](https://travis-ci.org/gaborcsardi/tamper.svg?branch=master)](https://travis-ci.org/gaborcsardi/tamper)
-<!--[![Windows Build status](https://ci.appveyor.com/api/projects/status/github/gaborcsardi/tamper?svg=true)](https://ci.appveyor.com/project/gaborcsardi/tamper)-->
+[![Windows Build status](https://ci.appveyor.com/api/projects/status/github/gaborcsardi/tamper?svg=true)](https://ci.appveyor.com/project/gaborcsardi/tamper)
 [![](http://www.r-pkg.org/badges/version/tamper)](http://www.r-pkg.org/pkg/tamper)
 [![CRAN RStudio mirror downloads](http://cranlogs.r-pkg.org/badges/tamper)](http://www.r-pkg.org/pkg/tamper)
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -1,8 +1,3 @@
----
-output: 
-  html_document: 
-    keep_md: yes
----
 
 ```{r, setup, echo = FALSE, message = FALSE}
 knitr::opts_chunk$set(

--- a/README.Rmd
+++ b/README.Rmd
@@ -13,7 +13,7 @@ knitr::opts_chunk$set(
 > Easier Debugging of `magrittr` Pipes
 
 [![Linux Build Status](https://travis-ci.org/gaborcsardi/tamper.svg?branch=master)](https://travis-ci.org/gaborcsardi/tamper)
-[![Windows Build status](https://ci.appveyor.com/api/projects/status/github/gaborcsardi/tamper?svg=true)](https://ci.appveyor.com/project/gaborcsardi/tamper)
+<!--[![Windows Build status](https://ci.appveyor.com/api/projects/status/github/gaborcsardi/tamper?svg=true)](https://ci.appveyor.com/project/gaborcsardi/tamper)-->
 [![](http://www.r-pkg.org/badges/version/tamper)](http://www.r-pkg.org/pkg/tamper)
 [![CRAN RStudio mirror downloads](http://cranlogs.r-pkg.org/badges/tamper)](http://www.r-pkg.org/pkg/tamper)
 
@@ -32,15 +32,43 @@ marks the place of the error, and helps saving the temporary results.
 devtools::install_github("gaborcsardi/tamper")
 ```
 
+## Rationale
+
+Pipes make code more readable, but their internal non-standard evaluation sorcery interacts poorly with some development tools, in particular `recover`, which helps inspecting the call stack after an error has occurred.
+
+```r
+library(magrittr)
+options(error = recover)
+1:10 %>%
+  multiply_by(10) %>%
+  add(10) %>%
+  add("oh no!") %>%
+  subtract(5) %>%
+  divide_by(5)
+  
+Error in add(., "oh no!") : non-numeric argument to binary operator
+
+Enter a frame number, or 0 to exit   
+
+1: 1:10 %>% multiply_by(10) %>% add(10) %>% add("oh no!") %>% subtract(5) %>% divide_by(5)
+2: withVisible(eval(quote(`_fseq`(`_lhs`)), env, env))
+3: eval(quote(`_fseq`(`_lhs`)), env, env)
+4: eval(expr, envir, enclos)
+5: `_fseq`(`_lhs`)
+6: freduce(value, `_function_list`)
+7: function_list[[i]](value)
+```
+
+Doh? What does that mean? Only @smbache knows! What are mere mortals to do? `tamper` to the rescue.
+
 ## Usage
 
 ```r
 options(error = tamper::tamper)
 ```
 
-Then, if you make a mistake in a pipeline, instead of the standard
-R stack trace, `tamper` is invoked and you can explore the data in
-the pipeline, and also save to a temporary variable.
+Then, if you make a mistake in a pipeline, instead of the above meta-mumbo-jumbo produced by a clueless `recover`, 
+`tamper` is invoked and you can explore the data in the pipeline, and also save to a temporary variable.
 
 ```r
 library(magrittr)


### PR DESCRIPTION
Hey Gabor, nice work. I thought you could show how really alien a magrittr stack looks like. That puts the question "do we need tamper?" under a different light -- even if I doubt having package-specific debugging tools is the way forward, but that's a longer story. So rather than complaining, I gave it a shot. Modify as you please. Can't generate the md because one of the build icons fails to load in pandoc, not sure why that is. Please take care of that.
